### PR TITLE
Adjustment of nonsnapshot-maven-plugin for our build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The plugin can be added to a separate (POM-) project or your main aggregator pro
 				<dontFailOnCommit>false</dontFailOnCommit>
 				<dontFailOnUpstreamVersionResolution>false</dontFailOnUpstreamVersionResolution>
 				<upstreamDependencies>
+					<bomDependency>
+						<upstreamDependency>at.nonblocking:all-bom:pom:2.10.3</upstreamDependency>
+					</bomDependency>
 					<upstreamDependency>at.nonblocking:*:LATEST</upstreamDependency>
 					<!-- Examples -->
 					<!-- <upstreamDependency>at.nonblocking:*:2.10</upstreamDependency> -->
@@ -98,6 +101,13 @@ The plugin can be added to a separate (POM-) project or your main aggregator pro
   ```xml
   	<upstreamDependency>at.nonblocking:test:2.3.4</upstreamDependency>
   	<upstreamDependency>at.nonblocking:*:LATEST</upstreamDependency>
+  ```
+* The upstream dependency list can contain dependencies to [bom artifacts](https://howtodoinjava.com/maven/maven-bom-bill-of-materials-dependency/). Artifacts pointed in that way are not only added as upstream dependecies but are being resolved and its dependencies are also added as upstream dependecies. If one that dependencies is bom (type: pom, scope: import) it is treated in the same way (recursively) 
+
+  ```xml
+    <bomDependency>
+        <upstreamDependency>at.nonblocking:all-bom:2.5.6</upstreamDependency>
+    </upstreamDependency>
   ```
 
 Usage

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/BomDependency.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/BomDependency.java
@@ -1,0 +1,14 @@
+package at.nonblocking.maven.nonsnapshot;
+
+
+public class BomDependency {
+    private String upstreamDependency;
+
+    public void setUpstreamDependency(String upstreamDependency) {
+        this.upstreamDependency = upstreamDependency;
+    }
+
+    public String getUpstreamDependency() {
+        return upstreamDependency;
+    }
+}

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/Constants.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/Constants.java
@@ -4,5 +4,6 @@ package at.nonblocking.maven.nonsnapshot;
  * @author Yablokov Aleksey
  */
 public interface Constants {
-    String DEFAULT_INCREMENT_VERSION_PATTERN = "(\\d+)\\.(\\d+)\\.(\\d+)(-(\\w[\\w-]*)-(\\d+|SNAPSHOT)|-(SNAPSHOT))?";
+    String DEFAULT_INCREMENT_VERSION_PATTERN = "^((\\d+)(\\.(\\d+)){2})(-(\\w[\\w-]*)-(\\d+|SNAPSHOT)|-(SNAPSHOT)|)$?";
+    String DEFAULT_UPSTREAM_DEPENDENCY_VERSION_PATTERN = "^((\\d+)(\\.(\\d+)){0,2})(-(\\w[\\w-]*)-(\\d+|SNAPSHOT)|-(SNAPSHOT)|)$|(^LATEST$|^$)?";
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/Constants.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/Constants.java
@@ -4,5 +4,5 @@ package at.nonblocking.maven.nonsnapshot;
  * @author Yablokov Aleksey
  */
 public interface Constants {
-    String DEFAULT_INCREMENT_VERSION_PATTERN = "(\\d+)\\.(\\d+)\\.(\\d+)(-(\\w[\\w-]*)-(\\d+))?";
+    String DEFAULT_INCREMENT_VERSION_PATTERN = "(\\d+)\\.(\\d+)\\.(\\d+)(-(\\w[\\w-]*)-(\\d+|SNAPSHOT)|-(SNAPSHOT))?";
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.impl.StaticLoggerBinder;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Properties;
 
 /**
@@ -94,7 +94,7 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
   private String timestampQualifierPattern = DEFAULT_TIMESTAMP_QUALIFIER_PATTERN;
 
   @Parameter
-  private List<String> upstreamDependencies;
+  private List upstreamDependencies;
 
   /**
    * Generate a property file with a property for all changed projects,
@@ -178,7 +178,8 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
 
     this.scmHandler.init(getMavenProject().getBasedir(), this.scmUser, this.scmPassword, properties);
 
-    this.processedUpstreamDependencies = this.upstreamDependencyHandler.processDependencyList(getUpstreamDependencies());
+    this.processedUpstreamDependencies = this.upstreamDependencyHandler.processDependencyList(
+            getUpstreamDependencies(), getMavenPomHandler(), getRepositorySystem(), getRepositorySystemSession(), getRemoteRepositories());
   }
 
   protected File getDirtyModulesRegistryFile() {
@@ -254,11 +255,11 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
     this.timestampQualifierPattern = timestampQualifierPattern;
   }
 
-  public List<String> getUpstreamDependencies() {
+  public List getUpstreamDependencies() {
     return upstreamDependencies;
   }
 
-  public void setUpstreamDependencies(List<String> upstreamDependencies) {
+  public void setUpstreamDependencies(List upstreamDependencies) {
     this.upstreamDependencies = upstreamDependencies;
   }
 

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
@@ -16,6 +16,7 @@
 package at.nonblocking.maven.nonsnapshot;
 
 import at.nonblocking.maven.nonsnapshot.impl.ScmHandlerGitImpl;
+import at.nonblocking.maven.nonsnapshot.model.MavenModule;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.impl.StaticLoggerBinder;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
@@ -386,6 +388,28 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
 
   public void setBranchName(String branchName) {
     this.branchName = branchName;
+  }
+
+  public String getCommitMessageUsingChangedMavenModules(List<MavenModule> changedMavenModules) {
+    StringBuilder message = new StringBuilder();
+    for (MavenModule changedMavenModule : changedMavenModules) {
+      message.append(" - ").append(changedMavenModule.getArtifactId()).append("-");
+      if(changedMavenModule.getNewVersion() != null)
+        message.append(changedMavenModule.getNewVersion()).append("\n");
+      else
+        message.append(changedMavenModule.getVersion()).append("\n");
+    }
+    return ScmHandler.NONSNAPSHOT_COMMIT_MESSAGE_PREFIX + " Version of " + changedMavenModules.size() + " artifacts updated\n\n"
+            + "Changes:\n" + message;
+  }
+
+  public String getCommitMessageUsingChangedPomFiles(List<File> changedPomFiles) {
+    List<MavenModule> changedMavenModules = new ArrayList<>();
+    for (File changedPomFile : changedPomFiles) {
+      MavenModule mavenModule = getMavenPomHandler().readArtifact(changedPomFile);
+      changedMavenModules.add(mavenModule);
+    }
+    return getCommitMessageUsingChangedMavenModules(changedMavenModules);
   }
 }
 

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotBaseMojo.java
@@ -136,6 +136,9 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
   @Parameter(defaultValue = "false", property = "nonsnapshot.appendBranchNameToVersion")
   private boolean appendBranchNameToVersion;
 
+  @Parameter(defaultValue = "false", property = "nonsnapshot.useSnapshotVersion")
+  private boolean useSnapshotVersion;
+
   @Parameter(property = "nonsnapshot.branchName")
   private String branchName;
 
@@ -373,6 +376,14 @@ abstract class NonSnapshotBaseMojo extends AbstractMojo implements Contextualiza
 
   public void setAppendBranchNameToVersion(boolean appendBranchNameToVersion) {
     this.appendBranchNameToVersion = appendBranchNameToVersion;
+  }
+
+  public boolean isUseSnapshotVersion() {
+    return useSnapshotVersion;
+  }
+
+  public void setUseSnapshotVersion(boolean useSnapshotVersion) {
+    this.useSnapshotVersion = useSnapshotVersion;
   }
 
   public String getReplaceSpecialSymbolsInVersionBy() {

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotCommitMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotCommitMojo.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import at.nonblocking.maven.nonsnapshot.model.MavenModule;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,8 @@ public class NonSnapshotCommitMojo extends NonSnapshotBaseMojo {
 
     try {
       LOG.info("Committing {} POM files", pomsToCommit.size());
-      getScmHandler().commitFiles(pomsToCommit, "Nonsnapshot Plugin: Version of " + pomsToCommit.size() + " modules updated");
+      String message = getCommitMessageUsingChangedPomFiles(pomsToCommit);
+      getScmHandler().commitFiles(pomsToCommit, message);
     } catch (RuntimeException e) {
       if (isDontFailOnCommit()) {
         LOG.warn("Error occurred during commit, ignoring it since dontFailOnCommit=true.", e);

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
@@ -117,7 +117,7 @@ public class NonSnapshotUpdateVersionsMojo extends NonSnapshotBaseMojo {
             writeDirtyModulesRegistry(pomsToCommit);
             if (!isDeferPomCommit()) {
                 LOG.info("Committing {} POM files", pomsToCommit.size());
-                String message = messageFormat(modulesToCommit);
+                String message = getCommitMessageUsingChangedMavenModules(modulesToCommit);
                 getScmHandler().commitFiles(pomsToCommit, message);
             } else {
                 LOG.info("Deferring the POM commit. Execute nonsnapshot:commit to actually commit the changes.");
@@ -126,15 +126,6 @@ public class NonSnapshotUpdateVersionsMojo extends NonSnapshotBaseMojo {
             LOG.info("Modules are up-to-date. No versions updated.");
         }
     }
-
-  static String messageFormat(List<MavenModule> modules) {
-    StringBuilder message = new StringBuilder();
-    for (MavenModule module : modules) {
-      message.append(module.getArtifactId()).append("-").append(module.getNewVersion()).append("\n");
-    }
-    return ScmHandler.NONSNAPSHOT_COMMIT_MESSAGE_PREFIX + " Version of " + modules.size() + " artifacts updated\n\n"
-            + "New versions:\n" + message;
-  }
 
   protected void markDirtyWhenRevisionChangedOrInvalidQualifier(List<MavenModule> mavenModules) {
     for (MavenModule mavenModule : mavenModules) {

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
@@ -195,7 +195,6 @@ public class NonSnapshotUpdateVersionsMojo extends NonSnapshotBaseMojo {
       ProcessedUpstreamDependency upstreamDependency = getUpstreamDependencyHandler().findMatch(upstreamArtifact, getProcessedUpstreamDependencies());
       if (upstreamDependency != null) {
         LOG.debug("Upstream dependency found: {}:{}", upstreamArtifact.getGroupId(), upstreamArtifact.getArtifactId());
-
         try {
           String latestVersion = getUpstreamDependencyHandler().resolveLatestVersion(upstreamArtifact, upstreamDependency, getRepositorySystem(), getRepositorySystemSession(), getRemoteRepositories());
           if (latestVersion != null) {

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
@@ -230,7 +230,7 @@ public class NonSnapshotUpdateVersionsMojo extends NonSnapshotBaseMojo {
           throw new NonSnapshotPluginException("Module path is no working directory: " + modulesPath);
         }
         String branch = getBranchName() != null ? getBranchName() : getScmHandler().getBranchName();
-        NewVersionResolver resolver = new NewVersionResolver(isAppendBranchNameToVersion(),
+        NewVersionResolver resolver = new NewVersionResolver(isAppendBranchNameToVersion(), isUseSnapshotVersion(),
                 getIncrementVersionPattern(), getReplaceSpecialSymbolsInVersionBy());
         String newVersion = resolver.resolveNewVersion(mavenModule.getVersion(), branch);
         mavenModule.setNewVersion(newVersion);

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/NonSnapshotUpdateVersionsMojo.java
@@ -200,7 +200,7 @@ public class NonSnapshotUpdateVersionsMojo extends NonSnapshotBaseMojo {
           String latestVersion = getUpstreamDependencyHandler().resolveLatestVersion(upstreamArtifact, upstreamDependency, getRepositorySystem(), getRepositorySystemSession(), getRemoteRepositories());
           if (latestVersion != null) {
             LOG.info("Found newer version for upstream dependency {}:{}: {}", new Object[]{upstreamArtifact.getGroupId(), upstreamArtifact.getArtifactId(), latestVersion});
-            return new UpdatedUpstreamMavenArtifact(upstreamArtifact.getGroupId(), upstreamArtifact.getArtifactId(), upstreamArtifact.getVersion(), latestVersion);
+            return new UpdatedUpstreamMavenArtifact(upstreamArtifact.getGroupId(), upstreamArtifact.getArtifactId(), upstreamArtifact.getVersion(), upstreamArtifact.getType(), latestVersion);
           }
         } catch (NonSnapshotDependencyResolverException e) {
           if (isDontFailOnUpstreamVersionResolution()) {

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/ProcessedUpstreamDependency.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/ProcessedUpstreamDependency.java
@@ -15,6 +15,8 @@
  */
 package at.nonblocking.maven.nonsnapshot;
 
+import at.nonblocking.maven.nonsnapshot.version.Version;
+
 import java.util.regex.Pattern;
 
 /**
@@ -26,16 +28,12 @@ public class ProcessedUpstreamDependency {
 
   private Pattern groupPattern;
   private Pattern artifactPattern;
-  private Integer versionMajor;
-  private Integer versionMinor;
-  private Integer versionIncrement;
+  private Version version;
 
-  public ProcessedUpstreamDependency(Pattern groupPattern, Pattern artifactPattern, Integer versionMajor, Integer versionMinor, Integer versionIncrement) {
+  public ProcessedUpstreamDependency(Pattern groupPattern, Pattern artifactPattern, Version version) {
     this.groupPattern = groupPattern;
     this.artifactPattern = artifactPattern;
-    this.versionMajor = versionMajor;
-    this.versionMinor = versionMinor;
-    this.versionIncrement = versionIncrement;
+    this.version = version;
   }
 
   public Pattern getGroupPattern() {
@@ -54,38 +52,16 @@ public class ProcessedUpstreamDependency {
     this.artifactPattern = artifactPattern;
   }
 
-  public Integer getVersionMajor() {
-    return versionMajor;
-  }
+  public Version getVersion() { return version; }
 
-  public void setVersionMajor(Integer versionMajor) {
-    this.versionMajor = versionMajor;
-  }
-
-  public Integer getVersionMinor() {
-    return versionMinor;
-  }
-
-  public void setVersionMinor(Integer versionMinor) {
-    this.versionMinor = versionMinor;
-  }
-
-  public Integer getVersionIncrement() {
-    return versionIncrement;
-  }
-
-  public void setVersionIncrement(Integer versionIncrement) {
-    this.versionIncrement = versionIncrement;
-  }
+  public void setVersionMajor(Version version) { this.version = version; }
 
   @Override
   public String toString() {
     return "UpstreamDependency{" +
         "groupPattern=" + groupPattern +
         ", artifactPattern=" + artifactPattern +
-        ", versionMajor=" + versionMajor +
-        ", versionMinor=" + versionMinor +
-        ", versionIncrement=" + versionIncrement +
+        ", version=" + version.toString() +
         '}';
   }
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandler.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandler.java
@@ -33,10 +33,19 @@ public interface UpstreamDependencyHandler {
   /**
    * Process the upstream dependency list from the configuration and create objects from it.
    *
-   * @param upstreamDependencyStrings List<String>
+   * @param upstreamDependencies List<>
+   * @param mavenPomHandler MavenPomHandler
+   * @param repositorySystem RepositorySystem
+   * @param repositorySystemSession RepositorySystemSession
+   * @param remoteRepositories List<RemoteRepository>
    * @return List<ProcessedUpstreamDependency>
+   * @throws NonSnapshotDependencyResolverException
    */
-  List<ProcessedUpstreamDependency> processDependencyList(List<String> upstreamDependencyStrings);
+  List<ProcessedUpstreamDependency> processDependencyList(List upstreamDependencies,
+                                                          MavenPomHandler mavenPomHandler,
+                                                          RepositorySystem repositorySystem,
+                                                          RepositorySystemSession repositorySystemSession,
+                                                          List<RemoteRepository> remoteRepositories);
 
   /**
    * Find a matching upstream dependency declaration for given maven artifact.

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/impl/MavenPomHandlerDefaultImpl.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/impl/MavenPomHandlerDefaultImpl.java
@@ -15,25 +15,13 @@
  */
 package at.nonblocking.maven.nonsnapshot.impl;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.LineNumberReader;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import at.nonblocking.maven.nonsnapshot.MavenPomHandler;
+import at.nonblocking.maven.nonsnapshot.exception.NonSnapshotPluginException;
+import at.nonblocking.maven.nonsnapshot.model.MavenArtifact;
+import at.nonblocking.maven.nonsnapshot.model.MavenModule;
+import at.nonblocking.maven.nonsnapshot.model.MavenModuleDependency;
 import at.nonblocking.maven.nonsnapshot.model.UpdatedUpstreamMavenArtifact;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.InputLocation;
-import org.apache.maven.model.InputLocationTracker;
-import org.apache.maven.model.InputSource;
-import org.apache.maven.model.Model;
-import org.apache.maven.model.Plugin;
-import org.apache.maven.model.Profile;
+import org.apache.maven.model.*;
 import org.apache.maven.model.io.xpp3.MavenXpp3ReaderEx;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.IOUtil;
@@ -42,11 +30,11 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import at.nonblocking.maven.nonsnapshot.MavenPomHandler;
-import at.nonblocking.maven.nonsnapshot.exception.NonSnapshotPluginException;
-import at.nonblocking.maven.nonsnapshot.model.MavenArtifact;
-import at.nonblocking.maven.nonsnapshot.model.MavenModule;
-import at.nonblocking.maven.nonsnapshot.model.MavenModuleDependency;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Default implementation of {@link MavenPomHandler}
@@ -158,6 +146,18 @@ public class MavenPomHandlerDefaultImpl implements MavenPomHandler {
                 new MavenArtifact(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion())));
           }
         }
+      }
+    }
+
+    // DependencyManagement Dependencies
+    LOG.info("Looking for dependencies management section in {}:{}", model.getGroupId(), model.getArtifactId());
+    DependencyManagement dependencyManagement = model.getDependencyManagement();
+    if(dependencyManagement != null) {
+      LOG.info("Processing dependencies management section in {}:{}", model.getGroupId(), model.getArtifactId());
+      for (Dependency dependency : dependencyManagement.getDependencies()) {
+        mavenModule.getDependencies().add(new MavenModuleDependency(
+                getVersionLocation(dependency),
+                new MavenArtifact(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion())));
       }
     }
 

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/model/MavenArtifact.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/model/MavenArtifact.java
@@ -24,11 +24,36 @@ public class MavenArtifact {
 
   private String groupId;
   private String artifactId;
+  private String type;
   private String version;
+
+  public MavenArtifact(String artifactDescription) {
+    String[] parts = artifactDescription.split(":");
+    if (parts.length < 2)
+      throw new IllegalArgumentException("Wrong maven artifact description: " + artifactDescription);
+
+    groupId = parts[0];
+    artifactId = parts[1];
+    if(parts.length == 4) {
+      type = parts[2];
+      version = parts[3];
+    }
+    else if(parts.length == 3) {
+      version = parts[2];
+    }
+  }
 
   public MavenArtifact(String groupId, String artifactId, String version) {
     this.groupId = groupId;
     this.artifactId = artifactId;
+    this.type = null;
+    this.version = version;
+  }
+
+  public MavenArtifact(String groupId, String artifactId, String type, String version) {
+    this.groupId = groupId;
+    this.artifactId = artifactId;
+    this.type = type;
     this.version = version;
   }
 
@@ -48,6 +73,14 @@ public class MavenArtifact {
     this.artifactId = artifactId;
   }
 
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
   public String getVersion() {
     return version;
   }
@@ -58,6 +91,12 @@ public class MavenArtifact {
 
   @Override
   public String toString() {
-      return groupId + ":" + artifactId + ":" + version;
+    StringBuilder builder = new StringBuilder(64);
+    builder.append(groupId).append(":").append(artifactId);
+    if(type != null)
+        builder.append(":").append(type);
+    if(version != null)
+      builder.append(":").append(version);
+    return builder.toString();
   }
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/model/MavenModuleDependency.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/model/MavenModuleDependency.java
@@ -25,10 +25,17 @@ public class MavenModuleDependency {
 
   private int versionLocation;
   private MavenArtifact artifact;
+  private String scope = null;
 
   public MavenModuleDependency(int versionLocation, MavenArtifact artifact) {
     this.versionLocation = versionLocation;
     this.artifact = artifact;
+  }
+
+  public MavenModuleDependency(int versionLocation, MavenArtifact artifact, String scope) {
+    this.versionLocation = versionLocation;
+    this.artifact = artifact;
+    this.scope = scope;
   }
 
   public int getVersionLocation() {
@@ -45,6 +52,14 @@ public class MavenModuleDependency {
 
   public void setArtifact(MavenArtifact artifact) {
     this.artifact = artifact;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public void setScope(String scope) {
+    this.scope = scope;
   }
 
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/model/UpdatedUpstreamMavenArtifact.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/model/UpdatedUpstreamMavenArtifact.java
@@ -29,8 +29,8 @@ public class UpdatedUpstreamMavenArtifact extends MavenArtifact {
     private String newVersion;
     private boolean dirty;
 
-    public UpdatedUpstreamMavenArtifact(String groupId, String artifactId, String currentVersion, String newVersion) {
-        super(groupId, artifactId, currentVersion);
+    public UpdatedUpstreamMavenArtifact(String groupId, String artifactId, String type, String currentVersion, String newVersion) {
+        super(groupId, artifactId, type, currentVersion);
         this.newVersion = newVersion;
         this.dirty = true;
     }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolver.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolver.java
@@ -11,11 +11,13 @@ import static at.nonblocking.maven.nonsnapshot.version.VersionIncrementer.remove
  */
 public class NewVersionResolver {
     private final boolean appendBranchNameToVersion;
+    private final boolean useSnapshotVersion;
     private final String replaceSpecialSymbolsInVersionBy;
     private final VersionParser parser;
 
-    public NewVersionResolver(boolean appendBranchNameToVersion, String incrementVersionPattern, String replaceSpecialSymbolsInVersionBy) {
+    public NewVersionResolver(boolean appendBranchNameToVersion, boolean useSnapshotVersion, String incrementVersionPattern, String replaceSpecialSymbolsInVersionBy) {
         this.appendBranchNameToVersion = appendBranchNameToVersion;
+        this.useSnapshotVersion = useSnapshotVersion;
         this.parser = new VersionParser(incrementVersionPattern);
         this.replaceSpecialSymbolsInVersionBy = replaceSpecialSymbolsInVersionBy;
     }
@@ -31,11 +33,12 @@ public class NewVersionResolver {
             if (branchName == null || branchName.isEmpty()) {
                 throw new IllegalArgumentException("Branch name is null");
             }
-            VersionParser.Version newV = incrementBuildVersion(currV, branchName);
+
+            VersionParser.Version newV = incrementBuildVersion(currV, branchName, useSnapshotVersion);
             newVersion = VersionFormatter.formatWithBranch(newV);
             newVersion = replaceSpecialSymbols(newVersion);
         } else {
-            VersionParser.Version newV = incrementMinorVersion(removeBranchName(currV));
+            VersionParser.Version newV = incrementMinorVersion(removeBranchName(currV), useSnapshotVersion);
             newVersion = VersionFormatter.formatWithBranch(newV);
         }
         return newVersion;

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolver.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolver.java
@@ -28,17 +28,17 @@ public class NewVersionResolver {
         }
 
         String newVersion;
-        VersionParser.Version currV = parser.parse(currVersion);
+        Version currV = parser.parse(currVersion);
         if (appendBranchNameToVersion) {
             if (branchName == null || branchName.isEmpty()) {
                 throw new IllegalArgumentException("Branch name is null");
             }
 
-            VersionParser.Version newV = incrementBuildVersion(currV, branchName, useSnapshotVersion);
+            Version newV = incrementBuildVersion(currV, branchName, useSnapshotVersion);
             newVersion = VersionFormatter.formatWithBranch(newV);
             newVersion = replaceSpecialSymbols(newVersion);
         } else {
-            VersionParser.Version newV = incrementMinorVersion(removeBranchName(currV), useSnapshotVersion);
+            Version newV = incrementMinorVersion(removeBranchName(currV), useSnapshotVersion);
             newVersion = VersionFormatter.formatWithBranch(newV);
         }
         return newVersion;

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/Version.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/Version.java
@@ -1,0 +1,90 @@
+package at.nonblocking.maven.nonsnapshot.version;
+
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Parse version of a module.
+ *
+ * @author Yablokov Aleksey
+ * @modified Piotr Borzęcki
+ */
+ public class Version {
+    private final Integer majorVersion;
+    private final Integer middleVersion;
+    private final Integer minorVersion;
+    private final String branchSuffix;
+    private final Integer buildVersion;
+    private final boolean isItSnapshot;
+
+    public Version(Integer majorVersion, Integer middleVersion, Integer minorVersion) {
+        this.majorVersion = majorVersion;
+        this.middleVersion = middleVersion;
+        this.minorVersion = minorVersion;
+        this.branchSuffix = null;
+        this.buildVersion = null;
+        this.isItSnapshot = false;
+    }
+
+    public Version(Integer majorVersion, Integer middleVersion, Integer minorVersion, String branchSuffix, Integer buildVersion, boolean isItSnapshot) {
+        this.majorVersion = majorVersion;
+        this.middleVersion = middleVersion;
+        this.minorVersion = minorVersion;
+        this.branchSuffix = branchSuffix;
+        this.buildVersion = buildVersion;
+        this.isItSnapshot = isItSnapshot;
+
+        if (branchSuffix != null && branchSuffix.isEmpty()) {
+            throw new IllegalArgumentException("Branch suffix is an empty string");
+        }
+        if (branchSuffix != null && buildVersion == null && !isItSnapshot) {
+            throw new IllegalArgumentException("Branch suffix is not null, but it is not SNAPSHOT and build version is null");
+        }
+        if (branchSuffix == null && buildVersion != null) {
+            throw new IllegalArgumentException("Build version is not null, but branch suffix is null");
+        }
+    }
+
+    public Integer getMajorVersion() {
+        return majorVersion;
+    }
+
+    public Integer getMiddleVersion() {
+        return middleVersion;
+    }
+
+    public Integer getMinorVersion() {
+        return minorVersion;
+    }
+
+    public String getBranchSuffix() {
+        return branchSuffix;
+    }
+
+    public Integer getBuildVersion() { return buildVersion; }
+
+    public boolean getIsItSnapshot() {
+        return isItSnapshot;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getMajorVersion());
+        if(getMiddleVersion() != null)
+            sb.append(".").append(getMiddleVersion());
+        if(getMinorVersion() != null)
+            sb.append(".").append(getMinorVersion());
+        if (getBranchSuffix() != null) {
+            if(getBuildVersion() != null) {
+                sb.append("-").append(getBranchSuffix()).append("-").append(getBuildVersion());
+            } else if(getIsItSnapshot())
+                sb.append("-").append(getBranchSuffix()).append("-SNAPSHOT");
+        }
+        else if(getIsItSnapshot())
+            sb.append("-SNAPSHOT");
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatter.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatter.java
@@ -10,11 +10,14 @@ class VersionFormatter {
         sb.append(version.getMajorVersion()).append(".");
         sb.append(version.getMiddleVersion()).append(".");
         sb.append(version.getMinorVersion());
-        if (version.getBranchSuffix() != null && version.getBuildVersion() != null) {
-            sb.append("-");
-            sb.append(version.getBranchSuffix()).append("-");
-            sb.append(version.getBuildVersion());
+        if (version.getBranchSuffix() != null) {
+            if(version.getBuildVersion() != null) {
+                sb.append("-").append(version.getBranchSuffix()).append("-").append(version.getBuildVersion());
+            } else if(version.getIsItSnapshot())
+                sb.append("-").append(version.getBranchSuffix()).append("-SNAPSHOT");
         }
+        else if(version.getIsItSnapshot())
+            sb.append("-SNAPSHOT");
         return sb.toString();
     }
 
@@ -23,6 +26,8 @@ class VersionFormatter {
         sb.append(version.getMajorVersion()).append(".");
         sb.append(version.getMiddleVersion()).append(".");
         sb.append(version.getMinorVersion());
+        if(version.getIsItSnapshot())
+            sb.append("-SNAPSHOT");
         return sb.toString();
     }
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatter.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatter.java
@@ -5,7 +5,7 @@ package at.nonblocking.maven.nonsnapshot.version;
  */
 class VersionFormatter {
 
-    static String formatWithBranch(VersionParser.Version version) {
+    static String formatWithBranch(Version version) {
         StringBuilder sb = new StringBuilder();
         sb.append(version.getMajorVersion()).append(".");
         sb.append(version.getMiddleVersion()).append(".");
@@ -21,7 +21,7 @@ class VersionFormatter {
         return sb.toString();
     }
 
-    static String formatWithoutBranch(VersionParser.Version version) {
+    static String formatWithoutBranch(Version version) {
         StringBuilder sb = new StringBuilder();
         sb.append(version.getMajorVersion()).append(".");
         sb.append(version.getMiddleVersion()).append(".");

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementer.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementer.java
@@ -5,13 +5,20 @@ package at.nonblocking.maven.nonsnapshot.version;
  */
 class VersionIncrementer {
 
-    static VersionParser.Version incrementMinorVersion(VersionParser.Version version) {
+    static VersionParser.Version incrementMinorVersion(VersionParser.Version version, boolean useSnapshot) {
+        Integer buildVersion = version.getBuildVersion();
+        if(useSnapshot || version.getBranchSuffix() == null)
+            buildVersion = null;
+        else if(buildVersion == null)
+            buildVersion = 1;
+
         return new VersionParser.Version(
                 version.getMajorVersion(),
                 version.getMiddleVersion(),
                 version.getMinorVersion() + 1,
                 version.getBranchSuffix(),
-                version.getBuildVersion()
+                buildVersion,
+                useSnapshot
         );
     }
 
@@ -21,28 +28,26 @@ class VersionIncrementer {
                 version.getMiddleVersion(),
                 version.getMinorVersion(),
                 null,
-                null
+                null,
+                version.getIsItSnapshot()
         );
     }
 
-    static VersionParser.Version incrementBuildVersion(VersionParser.Version version, String branchName) {
-        if (version.getBuildVersion() != null) {
-            return new VersionParser.Version(
-                    version.getMajorVersion(),
-                    version.getMiddleVersion(),
-                    version.getMinorVersion(),
-                    branchName,
-                    version.getBuildVersion() + 1
-            );
-        } else {
-            return new VersionParser.Version(
-                    version.getMajorVersion(),
-                    version.getMiddleVersion(),
-                    version.getMinorVersion(),
-                    branchName,
-                    1
-            );
-        }
+    static VersionParser.Version incrementBuildVersion(VersionParser.Version version, String branchName, boolean useSnapshot) {
+        Integer buildVersion =  version.getBuildVersion();
+        if(buildVersion != null)
+            buildVersion = useSnapshot ? null : buildVersion + 1;
+        else
+            buildVersion = useSnapshot ? null : 1;
+
+        return new VersionParser.Version(
+                version.getMajorVersion(),
+                version.getMiddleVersion(),
+                version.getMinorVersion(),
+                branchName,
+                buildVersion,
+                useSnapshot
+        );
     }
 
 }

--- a/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementer.java
+++ b/src/main/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementer.java
@@ -5,14 +5,14 @@ package at.nonblocking.maven.nonsnapshot.version;
  */
 class VersionIncrementer {
 
-    static VersionParser.Version incrementMinorVersion(VersionParser.Version version, boolean useSnapshot) {
+    static Version incrementMinorVersion(Version version, boolean useSnapshot) {
         Integer buildVersion = version.getBuildVersion();
         if(useSnapshot || version.getBranchSuffix() == null)
             buildVersion = null;
         else if(buildVersion == null)
             buildVersion = 1;
 
-        return new VersionParser.Version(
+        return new Version(
                 version.getMajorVersion(),
                 version.getMiddleVersion(),
                 version.getMinorVersion() + 1,
@@ -22,8 +22,8 @@ class VersionIncrementer {
         );
     }
 
-    static VersionParser.Version removeBranchName(VersionParser.Version version) {
-        return new VersionParser.Version(
+    static Version removeBranchName(Version version) {
+        return new Version(
                 version.getMajorVersion(),
                 version.getMiddleVersion(),
                 version.getMinorVersion(),
@@ -33,14 +33,14 @@ class VersionIncrementer {
         );
     }
 
-    static VersionParser.Version incrementBuildVersion(VersionParser.Version version, String branchName, boolean useSnapshot) {
+    static Version incrementBuildVersion(Version version, String branchName, boolean useSnapshot) {
         Integer buildVersion =  version.getBuildVersion();
         if(buildVersion != null)
             buildVersion = useSnapshot ? null : buildVersion + 1;
         else
             buildVersion = useSnapshot ? null : 1;
 
-        return new VersionParser.Version(
+        return new Version(
                 version.getMajorVersion(),
                 version.getMiddleVersion(),
                 version.getMinorVersion(),

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/MavenPomHandlerDefaultImplTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/MavenPomHandlerDefaultImplTest.java
@@ -16,8 +16,13 @@ import org.slf4j.impl.StaticLoggerBinder;
 
 import at.nonblocking.maven.nonsnapshot.impl.MavenPomHandlerDefaultImpl;
 import at.nonblocking.maven.nonsnapshot.model.MavenModule;
+import at.nonblocking.maven.nonsnapshot.ResourcesToolkit;
 
 public class MavenPomHandlerDefaultImplTest {
+
+  private final String testPom = new String("test-pom.xml");
+  private final String testPomParent = new String("test-pom-parent.xml");
+  private final String testPomNoVersion = new String("test-pom-noversion.xml");
 
   @BeforeClass
   public static void setupLog() {
@@ -26,8 +31,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadArtifact() throws Exception {
-    File pomFile = new File("target/test-pom.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPom));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPom)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 
@@ -52,8 +57,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadArtifactWithParent() throws Exception {
-    File pomFile = new File("target/test-pom-parent.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom-parent.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPomParent));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPomParent)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 
@@ -71,8 +76,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadAndUpdateArtifact() throws Exception {
-    File pomFile = new File("target/test-pom.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPom));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPom)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 
@@ -97,8 +102,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadAndUpdateArtifactWithParent() throws Exception {
-    File pomFile = new File("target/test-pom-parent.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom-parent.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPomParent));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPomParent)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 
@@ -123,8 +128,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadAndUpdateArtifactWithNoVersion() throws Exception {
-    File pomFile = new File("target/test-pom-noversion.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom-noversion.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPomNoVersion));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPomNoVersion)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 
@@ -145,8 +150,8 @@ public class MavenPomHandlerDefaultImplTest {
 
   @Test
   public void testReadAndUpdateArtifactInsertVersionTag() throws Exception {
-    File pomFile = new File("target/test-pom.xml");
-    IOUtil.copy(new FileReader("src/test/resources/test-pom.xml"), new FileOutputStream(pomFile));
+    File pomFile = new File(ResourcesToolkit.GetPathToResourceInTarget(testPom));
+    IOUtil.copy(new FileReader(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), testPom)), new FileOutputStream(pomFile));
 
     MavenPomHandler pomHandler = new MavenPomHandlerDefaultImpl();
 

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/ModuleTraverserDefaultImplTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/ModuleTraverserDefaultImplTest.java
@@ -1,6 +1,8 @@
 package at.nonblocking.maven.nonsnapshot;
 
 import at.nonblocking.maven.nonsnapshot.impl.ModuleTraverserDefaultImpl;
+import at.nonblocking.maven.nonsnapshot.ResourcesToolkit;
+
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Profile;
 import org.apache.maven.project.MavenProject;
@@ -14,10 +16,12 @@ import java.util.List;
 
 public class ModuleTraverserDefaultImplTest {
 
+  private final String project1Pom = new String("testworkspace/project1/pom.xml");
+
   @Test
   public void readModulesNoProfilesTest() {
     MavenProject mavenProject = new MavenProject();
-    mavenProject.setFile(new File("src/test/resources/testworkspace/project1/pom.xml"));
+    mavenProject.setFile(new File(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), project1Pom)));
 
     ModuleTraverser moduleTraverser = new ModuleTraverserDefaultImpl();
 
@@ -35,7 +39,7 @@ public class ModuleTraverserDefaultImplTest {
   @Test
   public void readModulesInProfilesTest() {
     MavenProject mavenProject = new MavenProject();
-    mavenProject.setFile(new File("src/test/resources/testworkspace/project1/pom.xml"));
+    mavenProject.setFile(new File(ResourcesToolkit.GetPathToResourceInResourcesDir(getClass(), project1Pom)));
 
     ModuleTraverser moduleTraverser = new ModuleTraverserDefaultImpl();
 

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/ResourcesToolkit.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/ResourcesToolkit.java
@@ -1,0 +1,15 @@
+package at.nonblocking.maven.nonsnapshot;
+
+public class ResourcesToolkit {
+
+  public static String GetPathToResourceInTarget(String resource)
+  {
+    return "target/" + resource;
+  }
+
+  public static String GetPathToResourceInResourcesDir(Class c, String resource)
+  {
+    return c.getClassLoader().getResource(resource).getPath();
+  }
+
+}

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandlerDefaultImplTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandlerDefaultImplTest.java
@@ -33,7 +33,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 
-    List<ProcessedUpstreamDependency> upstreamDependencies = handler.processDependencyList(upstreamDependencyStrings);
+    List<ProcessedUpstreamDependency> upstreamDependencies = handler.processDependencyList(upstreamDependencyStrings, null, null, null, null);
 
     assertNotNull(upstreamDependencies);
     assertEquals(5, upstreamDependencies.size());

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandlerDefaultImplTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/UpstreamDependencyHandlerDefaultImplTest.java
@@ -2,12 +2,12 @@ package at.nonblocking.maven.nonsnapshot;
 
 import at.nonblocking.maven.nonsnapshot.impl.UpstreamDependencyHandlerDefaultImpl;
 import at.nonblocking.maven.nonsnapshot.model.MavenArtifact;
+import at.nonblocking.maven.nonsnapshot.version.Version;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
-import org.eclipse.aether.version.Version;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -40,40 +40,40 @@ public class UpstreamDependencyHandlerDefaultImplTest {
 
     assertEquals("at\\.nonblocking", upstreamDependencies.get(0).getGroupPattern().pattern());
     assertEquals("test2", upstreamDependencies.get(0).getArtifactPattern().pattern());
-    assertEquals(new Integer(1), upstreamDependencies.get(0).getVersionMajor());
-    assertEquals(new Integer(2), upstreamDependencies.get(0).getVersionMinor());
-    assertEquals(new Integer(4), upstreamDependencies.get(0).getVersionIncrement());
+    assertEquals(new Integer(1), upstreamDependencies.get(0).getVersion().getMajorVersion());
+    assertEquals(new Integer(2), upstreamDependencies.get(0).getVersion().getMiddleVersion());
+    assertEquals(new Integer(4), upstreamDependencies.get(0).getVersion().getMinorVersion());
 
     assertEquals("at\\.nonblocking", upstreamDependencies.get(1).getGroupPattern().pattern());
     assertEquals("test3", upstreamDependencies.get(1).getArtifactPattern().pattern());
-    assertEquals(new Integer(1), upstreamDependencies.get(1).getVersionMajor());
-    assertEquals(new Integer(5), upstreamDependencies.get(1).getVersionMinor());
-    assertNull(upstreamDependencies.get(1).getVersionIncrement());
+    assertEquals(new Integer(1), upstreamDependencies.get(1).getVersion().getMajorVersion());
+    assertEquals(new Integer(5), upstreamDependencies.get(1).getVersion().getMiddleVersion());
+    assertNull(upstreamDependencies.get(1).getVersion().getMinorVersion());
 
     assertEquals("at\\.nonblocking", upstreamDependencies.get(2).getGroupPattern().pattern());
     assertEquals("test-.*", upstreamDependencies.get(2).getArtifactPattern().pattern());
-    assertNull(upstreamDependencies.get(2).getVersionMajor());
-    assertNull(upstreamDependencies.get(2).getVersionMinor());
-    assertNull(upstreamDependencies.get(2).getVersionIncrement());
+    assertNull(upstreamDependencies.get(2).getVersion().getMajorVersion());
+    assertNull(upstreamDependencies.get(2).getVersion().getMiddleVersion());
+    assertNull(upstreamDependencies.get(2).getVersion().getMinorVersion());
 
     assertEquals("at\\..*", upstreamDependencies.get(3).getGroupPattern().pattern());
     assertEquals("test5", upstreamDependencies.get(3).getArtifactPattern().pattern());
-    assertNull(upstreamDependencies.get(3).getVersionMajor());
-    assertNull(upstreamDependencies.get(3).getVersionMinor());
-    assertNull(upstreamDependencies.get(3).getVersionIncrement());
+    assertNull(upstreamDependencies.get(3).getVersion().getMajorVersion());
+    assertNull(upstreamDependencies.get(3).getVersion().getMiddleVersion());
+    assertNull(upstreamDependencies.get(3).getVersion().getMinorVersion());
 
     assertEquals("at\\..*", upstreamDependencies.get(4).getGroupPattern().pattern());
     assertEquals(".*", upstreamDependencies.get(4).getArtifactPattern().pattern());
-    assertEquals(new Integer(1), upstreamDependencies.get(4).getVersionMajor());
-    assertNull(upstreamDependencies.get(4).getVersionMinor());
-    assertNull(upstreamDependencies.get(4).getVersionIncrement());
+    assertEquals(new Integer(1), upstreamDependencies.get(4).getVersion().getMajorVersion());
+    assertNull(upstreamDependencies.get(4).getVersion().getMiddleVersion());
+    assertNull(upstreamDependencies.get(4).getVersion().getMinorVersion());
   }
 
   @Test
   public void testMatches() {
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), null, null, null);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(null, null, null));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     List<ProcessedUpstreamDependency> upstreamDependencies = Arrays.asList(dep1, dep2);
 
@@ -90,7 +90,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     RepositorySystemSession mockRepositorySystemSession = mock(RepositorySystemSession.class);
     List<RemoteRepository> mockRemoteRepositories = new ArrayList<>();
 
-    Version mockVersion1 = mock(Version.class);
+    org.eclipse.aether.version.Version mockVersion1 = mock(org.eclipse.aether.version.Version.class);
     when(mockVersion1.toString()).thenReturn("1.1.1-1234");
 
     VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
@@ -99,8 +99,8 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     ArgumentCaptor<VersionRangeRequest> captor = ArgumentCaptor.forClass(VersionRangeRequest.class);
     when(mockRepositorySystem.resolveVersionRange(any(RepositorySystemSession.class), captor.capture())).thenReturn(result);
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), null, null, null);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(null, null, null));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 
@@ -119,7 +119,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     RepositorySystemSession mockRepositorySystemSession = mock(RepositorySystemSession.class);
     List<RemoteRepository> mockRemoteRepositories = new ArrayList<>();
 
-    Version mockVersion1 = mock(Version.class);
+    org.eclipse.aether.version.Version mockVersion1 = mock(org.eclipse.aether.version.Version.class);
     when(mockVersion1.toString()).thenReturn("2.1.1-1234");
 
     VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
@@ -128,8 +128,8 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     ArgumentCaptor<VersionRangeRequest> captor = ArgumentCaptor.forClass(VersionRangeRequest.class);
     when(mockRepositorySystem.resolveVersionRange(any(RepositorySystemSession.class), captor.capture())).thenReturn(result);
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), 2, null, null);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(2, null, null));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 
@@ -148,7 +148,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     RepositorySystemSession mockRepositorySystemSession = mock(RepositorySystemSession.class);
     List<RemoteRepository> mockRemoteRepositories = new ArrayList<>();
 
-    Version mockVersion1 = mock(Version.class);
+    org.eclipse.aether.version.Version mockVersion1 = mock(org.eclipse.aether.version.Version.class);
     when(mockVersion1.toString()).thenReturn("1.1.1-1234");
 
     VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
@@ -157,8 +157,8 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     ArgumentCaptor<VersionRangeRequest> captor = ArgumentCaptor.forClass(VersionRangeRequest.class);
     when(mockRepositorySystem.resolveVersionRange(any(RepositorySystemSession.class), captor.capture())).thenReturn(result);
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), 2, null, null);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(2, null, null));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 
@@ -176,7 +176,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     RepositorySystemSession mockRepositorySystemSession = mock(RepositorySystemSession.class);
     List<RemoteRepository> mockRemoteRepositories = new ArrayList<>();
 
-    Version mockVersion1 = mock(Version.class);
+    org.eclipse.aether.version.Version mockVersion1 = mock(org.eclipse.aether.version.Version.class);
     when(mockVersion1.toString()).thenReturn("2.3.9-1234");
 
     VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
@@ -185,8 +185,8 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     ArgumentCaptor<VersionRangeRequest> captor = ArgumentCaptor.forClass(VersionRangeRequest.class);
     when(mockRepositorySystem.resolveVersionRange(any(RepositorySystemSession.class), captor.capture())).thenReturn(result);
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), 2, 3, null);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(2, 3, null));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 
@@ -205,7 +205,7 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     RepositorySystemSession mockRepositorySystemSession = mock(RepositorySystemSession.class);
     List<RemoteRepository> mockRemoteRepositories = new ArrayList<>();
 
-    Version mockVersion1 = mock(Version.class);
+    org.eclipse.aether.version.Version mockVersion1 = mock(org.eclipse.aether.version.Version.class);
     when(mockVersion1.toString()).thenReturn("2.3.4-1234");
 
     VersionRangeResult result = new VersionRangeResult(new VersionRangeRequest());
@@ -214,8 +214,8 @@ public class UpstreamDependencyHandlerDefaultImplTest {
     ArgumentCaptor<VersionRangeRequest> captor = ArgumentCaptor.forClass(VersionRangeRequest.class);
     when(mockRepositorySystem.resolveVersionRange(any(RepositorySystemSession.class), captor.capture())).thenReturn(result);
 
-    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), 2, 3, 4);
-    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), null, null, null);
+    ProcessedUpstreamDependency dep1 = new ProcessedUpstreamDependency(Pattern.compile("at\\.nonblocking"), Pattern.compile("test1"), new Version(2, 3, 4));
+    ProcessedUpstreamDependency dep2 = new ProcessedUpstreamDependency(Pattern.compile("at\\..*"), Pattern.compile(".*"), new Version(null, null, null));
 
     UpstreamDependencyHandler handler = new UpstreamDependencyHandlerDefaultImpl();
 

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolverTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/NewVersionResolverTest.java
@@ -10,21 +10,30 @@ import static org.junit.Assert.assertThat;
  * @author Yablokov Aleksey
  */
 public class NewVersionResolverTest {
-    private static final NewVersionResolver resolver = new NewVersionResolver(true, DEFAULT_INCREMENT_VERSION_PATTERN, null);
-
     @Test
     public void noAppendBranchNameToVersion() {
-        NewVersionResolver resolver = new NewVersionResolver(false, DEFAULT_INCREMENT_VERSION_PATTERN, null);
+        NewVersionResolver resolver = new NewVersionResolver(false, false, DEFAULT_INCREMENT_VERSION_PATTERN, null);
         assertThat(resolver.resolveNewVersion("1.2.3", "master"), equalTo("1.2.4"));
+
+        resolver = new NewVersionResolver(false, true, DEFAULT_INCREMENT_VERSION_PATTERN, null);
+        assertThat(resolver.resolveNewVersion("1.2.3", "master"), equalTo("1.2.4-SNAPSHOT"));
     }
 
     @Test
     public void appendBranchNameToVersion() {
+        NewVersionResolver resolver = new NewVersionResolver(true, false, DEFAULT_INCREMENT_VERSION_PATTERN, null);
         assertThat(resolver.resolveNewVersion("1.2.3", "master"), equalTo("1.2.3-master-1"));
+
+        resolver = new NewVersionResolver(true, true, DEFAULT_INCREMENT_VERSION_PATTERN, null);
+        assertThat(resolver.resolveNewVersion("1.2.3", "master"), equalTo("1.2.3-master-SNAPSHOT"));
     }
 
     @Test
     public void replaceSuffix() {
+        NewVersionResolver resolver = new NewVersionResolver(true, false, DEFAULT_INCREMENT_VERSION_PATTERN, null);
         assertThat(resolver.resolveNewVersion("1.2.3-pks-10", "master"), equalTo("1.2.3-master-11"));
+
+        resolver = new NewVersionResolver(true, true, DEFAULT_INCREMENT_VERSION_PATTERN, null);
+        assertThat(resolver.resolveNewVersion("1.2.3-pks-10", "master"), equalTo("1.2.3-master-SNAPSHOT"));
     }
 }

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatterTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatterTest.java
@@ -12,22 +12,31 @@ import static org.junit.Assert.assertThat;
  * @author Yablokov Aleksey
  */
 public class VersionFormatterTest {
-    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null);
-    private static final VersionParser.Version easyBranch = new VersionParser.Version(1, 2, 3, "master", 4);
-    private static final VersionParser.Version hardBranch = new VersionParser.Version(1, 2, 3, "pks-1234-bnu-integration-5", 4);
+    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null, false);
+    private static final VersionParser.Version noBranchSnapshot = new VersionParser.Version(1, 2, 3, null, null, true);
+    private static final VersionParser.Version easyBranch = new VersionParser.Version(1, 2, 3, "master", 4, false);
+    private static final VersionParser.Version easyBranchSnapshot = new VersionParser.Version(1, 2, 3, "master", null, true);
+    private static final VersionParser.Version hardBranch = new VersionParser.Version(1, 2, 3, "pks-1234-bnu-integration-5", 4, false);
+    private static final VersionParser.Version hardBranchSnapshot = new VersionParser.Version(1, 2, 3, "pks-1234-bnu-integration-5", null, true);
 
     @Test
     public void withBranch() {
         assertThat(formatWithBranch(noBranch), equalTo("1.2.3"));
+        assertThat(formatWithBranch(noBranchSnapshot), equalTo("1.2.3-SNAPSHOT"));
         assertThat(formatWithBranch(easyBranch), equalTo("1.2.3-master-4"));
+        assertThat(formatWithBranch(easyBranchSnapshot), equalTo("1.2.3-master-SNAPSHOT"));
         assertThat(formatWithBranch(hardBranch), equalTo("1.2.3-pks-1234-bnu-integration-5-4"));
+        assertThat(formatWithBranch(hardBranchSnapshot), equalTo("1.2.3-pks-1234-bnu-integration-5-SNAPSHOT"));
     }
 
     @Test
     public void withoutBranch() {
         assertThat(formatWithoutBranch(noBranch), equalTo("1.2.3"));
+        assertThat(formatWithoutBranch(noBranchSnapshot), equalTo("1.2.3-SNAPSHOT"));
         assertThat(formatWithoutBranch(easyBranch), equalTo("1.2.3"));
+        assertThat(formatWithoutBranch(easyBranchSnapshot), equalTo("1.2.3-SNAPSHOT"));
         assertThat(formatWithoutBranch(hardBranch), equalTo("1.2.3"));
+        assertThat(formatWithoutBranch(hardBranchSnapshot), equalTo("1.2.3-SNAPSHOT"));
     }
 
 }

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatterTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionFormatterTest.java
@@ -12,12 +12,12 @@ import static org.junit.Assert.assertThat;
  * @author Yablokov Aleksey
  */
 public class VersionFormatterTest {
-    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null, false);
-    private static final VersionParser.Version noBranchSnapshot = new VersionParser.Version(1, 2, 3, null, null, true);
-    private static final VersionParser.Version easyBranch = new VersionParser.Version(1, 2, 3, "master", 4, false);
-    private static final VersionParser.Version easyBranchSnapshot = new VersionParser.Version(1, 2, 3, "master", null, true);
-    private static final VersionParser.Version hardBranch = new VersionParser.Version(1, 2, 3, "pks-1234-bnu-integration-5", 4, false);
-    private static final VersionParser.Version hardBranchSnapshot = new VersionParser.Version(1, 2, 3, "pks-1234-bnu-integration-5", null, true);
+    private static final Version noBranch = new Version(1, 2, 3, null, null, false);
+    private static final Version noBranchSnapshot = new Version(1, 2, 3, null, null, true);
+    private static final Version easyBranch = new Version(1, 2, 3, "master", 4, false);
+    private static final Version easyBranchSnapshot = new Version(1, 2, 3, "master", null, true);
+    private static final Version hardBranch = new Version(1, 2, 3, "pks-1234-bnu-integration-5", 4, false);
+    private static final Version hardBranchSnapshot = new Version(1, 2, 3, "pks-1234-bnu-integration-5", null, true);
 
     @Test
     public void withBranch() {

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementerTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementerTest.java
@@ -9,10 +9,10 @@ import static at.nonblocking.maven.nonsnapshot.version.VersionIncrementer.increm
  * @author Yablokov Aleksey
  */
 public class VersionIncrementerTest {
-    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null, false);
-    private static final VersionParser.Version noBranchSnapshot = new VersionParser.Version(1, 2, 3, null, null, true);
-    private static final VersionParser.Version withBranch = new VersionParser.Version(1, 2, 3, "master", 4, false);
-    private static final VersionParser.Version withBranchSnapshot = new VersionParser.Version(1, 2, 3, "master", null, true);
+    private static final Version noBranch = new Version(1, 2, 3, null, null, false);
+    private static final Version noBranchSnapshot = new Version(1, 2, 3, null, null, true);
+    private static final Version withBranch = new Version(1, 2, 3, "master", 4, false);
+    private static final Version withBranchSnapshot = new Version(1, 2, 3, "master", null, true);
 
     @Test
     public void incrementMinorVersionTest() {

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementerTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionIncrementerTest.java
@@ -9,20 +9,33 @@ import static at.nonblocking.maven.nonsnapshot.version.VersionIncrementer.increm
  * @author Yablokov Aleksey
  */
 public class VersionIncrementerTest {
-    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null);
-    private static final VersionParser.Version withBranch = new VersionParser.Version(1, 2, 3, "master", 4);
+    private static final VersionParser.Version noBranch = new VersionParser.Version(1, 2, 3, null, null, false);
+    private static final VersionParser.Version noBranchSnapshot = new VersionParser.Version(1, 2, 3, null, null, true);
+    private static final VersionParser.Version withBranch = new VersionParser.Version(1, 2, 3, "master", 4, false);
+    private static final VersionParser.Version withBranchSnapshot = new VersionParser.Version(1, 2, 3, "master", null, true);
 
     @Test
     public void incrementMinorVersionTest() {
-        VersionParserTest.assertVersionEquals(incrementMinorVersion(noBranch), 1, 2, 4, null, null);
-        VersionParserTest.assertVersionEquals(incrementMinorVersion(withBranch), 1, 2, 4, "master", 4);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(noBranch, false), 1, 2, 4, null, null, false);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(noBranch, true), 1, 2, 4, null, null, true);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(noBranchSnapshot, false), 1, 2, 4, null, null, false);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(noBranchSnapshot, true), 1, 2, 4, null, null, true);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(withBranch, false), 1, 2, 4, "master", 4, false);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(withBranch, true), 1, 2, 4, "master", null, true);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(withBranchSnapshot, false), 1, 2, 4, "master", 1, false);
+        VersionParserTest.assertVersionEquals(incrementMinorVersion(withBranchSnapshot, true), 1, 2, 4, "master", null, true);
     }
 
     @Test
     public void incrementBuildVersionTest() {
-        VersionParserTest.assertVersionEquals(incrementBuildVersion(noBranch, "master"), 1, 2, 3, "master", 1);
-        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "master"), 1, 2, 3, "master", 5);
-        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "gvc-3"), 1, 2, 3, "gvc-3", 5);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(noBranch, "master", false), 1, 2, 3, "master", 1, false);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(noBranch, "master", true), 1, 2, 3, "master", null, true);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(noBranchSnapshot, "master", false), 1, 2, 3, "master", 1, false);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(noBranchSnapshot, "master", true), 1, 2, 3, "master", null, true);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "master", false), 1, 2, 3, "master", 5, false);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "master", true), 1, 2, 3, "master", null, true);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "gvc-3", false), 1, 2, 3, "gvc-3", 5, false);
+        VersionParserTest.assertVersionEquals(incrementBuildVersion(withBranch, "gvc-3", true), 1, 2, 3, "gvc-3", null, true);
     }
 
 }

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionParserTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionParserTest.java
@@ -3,42 +3,115 @@ package at.nonblocking.maven.nonsnapshot.version;
 import org.junit.Test;
 
 import static at.nonblocking.maven.nonsnapshot.Constants.DEFAULT_INCREMENT_VERSION_PATTERN;
+import static at.nonblocking.maven.nonsnapshot.Constants.DEFAULT_UPSTREAM_DEPENDENCY_VERSION_PATTERN;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 /**
  * @author Yablokov Aleksey
  */
 public class VersionParserTest {
 
-    private static final VersionParser parser = new VersionParser(DEFAULT_INCREMENT_VERSION_PATTERN);
+    private static final VersionParser incrementVersionParser = new VersionParser(DEFAULT_INCREMENT_VERSION_PATTERN);
+    private static final VersionParser upstreamDependencyVersionParser = new VersionParser(DEFAULT_UPSTREAM_DEPENDENCY_VERSION_PATTERN);
 
     @Test
     public void noBranch() {
-        assertVersionEquals(parser.parse("1.2.3"), 1, 2, 3, null, null, false);
-        assertVersionEquals(parser.parse("11.22.33"), 11, 22, 33, null, null, false);
-        assertVersionEquals(parser.parse("11.22.33-SNAPSHOT"), 11, 22, 33, null, null, true);
+        VersionParser p = incrementVersionParser;
+        assertParsingThrows(p, "");
+        assertParsingThrows(p, "LATEST");
+        assertParsingThrows(p, "1");
+        assertParsingThrows(p, "1-SNAPSHOT");
+        assertParsingThrows(p, "1.2");
+        assertParsingThrows(p, "1.2-SNAPSHOT");
+        assertVersionEquals(p.parse("1.2.3"), 1, 2, 3, null, null, false);
+        assertVersionEquals(p.parse("1.2.3-SNAPSHOT"), 1, 2, 3, null, null, true);
+
+        p = upstreamDependencyVersionParser;
+        assertVersionEquals(p.parse(""), null, null, null, null, null, false);
+        assertVersionEquals(p.parse("LATEST"), null, null, null, null, null, false);
+        assertVersionEquals(p.parse("1"), 1, null, null, null, null, false);
+        assertVersionEquals(p.parse("1-SNAPSHOT"), 1, null, null, null, null, true);
+        assertVersionEquals(p.parse("1.2"), 1, 2, null, null, null, false);
+        assertVersionEquals(p.parse("1.2-SNAPSHOT"), 1, 2, null, null, null, true);
+        assertVersionEquals(p.parse("1.2.3"), 1, 2, 3, null, null, false);
+        assertVersionEquals(p.parse("1.2.3-SNAPSHOT"), 1, 2, 3, null, null, true);
     }
 
     @Test
     public void withBranch() {
-        assertVersionEquals(parser.parse("1.2.3-master-4"), 1, 2, 3, "master", 4, false);
-        assertVersionEquals(parser.parse("1.2.3-master-SNAPSHOT"), 1, 2, 3, "master", null, true);
-        assertVersionEquals(parser.parse("1.2.3-gvc-4-5"), 1, 2, 3, "gvc-4", 5, false);
-        assertVersionEquals(parser.parse("1.2.3-gvc-4-SNAPSHOT"), 1, 2, 3, "gvc-4", null, true);
-        assertVersionEquals(parser.parse("1.2.3-release-gvc-4-5"), 1, 2, 3, "release-gvc-4", 5, false);
-        assertVersionEquals(parser.parse("1.2.3-release-gvc-4-SNAPSHOT"), 1, 2, 3, "release-gvc-4", null, true);
-        assertVersionEquals(parser.parse("1.2.3-pks-1234-bnu-integration-5"), 1, 2, 3, "pks-1234-bnu-integration", 5, false);
-        assertVersionEquals(parser.parse("1.2.3-pks-1234-bnu-integration-SNAPSHOT"), 1, 2, 3, "pks-1234-bnu-integration", null, true);
+        VersionParser p = incrementVersionParser;
+        assertParsingThrows(p, "1-master-4");
+        assertParsingThrows(p, "1-master-SNAPSHOT");
+        assertParsingThrows(p, "1-gvc-4-5");
+        assertParsingThrows(p, "1-gvc-4-SNAPSHOT");
+        assertParsingThrows(p, "1-release-gvc-4-5");
+        assertParsingThrows(p, "1-release-gvc-4-SNAPSHOT");
+        assertParsingThrows(p, "1-pks-1234-bnu-integration-5");
+        assertParsingThrows(p, "1-pks-1234-bnu-integration-SNAPSHOT");
+        assertParsingThrows(p, "1-master-4");
+        assertParsingThrows(p, "1.2-master-4");
+        assertParsingThrows(p, "1.2-master-SNAPSHOT");
+        assertParsingThrows(p, "1.2-gvc-4-5");
+        assertParsingThrows(p, "1.2-gvc-4-SNAPSHOT");
+        assertParsingThrows(p, "1.2-release-gvc-4-5");
+        assertParsingThrows(p, "1.2-release-gvc-4-SNAPSHOT");
+        assertParsingThrows(p, "1.2-pks-1234-bnu-integration-5");
+        assertParsingThrows(p, "1.2-pks-1234-bnu-integration-SNAPSHOT");
+        assertVersionEquals(p.parse("1.2.3-master-4"), 1, 2, 3, "master", 4, false);
+        assertVersionEquals(p.parse("1.2.3-master-SNAPSHOT"), 1, 2, 3, "master", null, true);
+        assertVersionEquals(p.parse("1.2.3-gvc-4-5"), 1, 2, 3, "gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2.3-gvc-4-SNAPSHOT"), 1, 2, 3, "gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2.3-release-gvc-4-5"), 1, 2, 3, "release-gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2.3-release-gvc-4-SNAPSHOT"), 1, 2, 3, "release-gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2.3-pks-1234-bnu-integration-5"), 1, 2, 3, "pks-1234-bnu-integration", 5, false);
+        assertVersionEquals(p.parse("1.2.3-pks-1234-bnu-integration-SNAPSHOT"), 1, 2, 3, "pks-1234-bnu-integration", null, true);
+
+
+        p = upstreamDependencyVersionParser;
+        assertVersionEquals(p.parse("1-master-4"), 1, null, null, "master", 4, false);
+        assertVersionEquals(p.parse("1-master-SNAPSHOT"), 1, null, null, "master", null, true);
+        assertVersionEquals(p.parse("1-gvc-4-5"), 1, null, null, "gvc-4", 5, false);
+        assertVersionEquals(p.parse("1-gvc-4-SNAPSHOT"), 1, null, null, "gvc-4", null, true);
+        assertVersionEquals(p.parse("1-release-gvc-4-5"), 1, null, null, "release-gvc-4", 5, false);
+        assertVersionEquals(p.parse("1-release-gvc-4-SNAPSHOT"), 1, null, null, "release-gvc-4", null, true);
+        assertVersionEquals(p.parse("1-pks-1234-bnu-integration-5"), 1, null, null, "pks-1234-bnu-integration", 5, false);
+        assertVersionEquals(p.parse("1-pks-1234-bnu-integration-SNAPSHOT"), 1, null, null, "pks-1234-bnu-integration", null, true);
+        assertVersionEquals(p.parse("1.2-master-4"), 1, 2, null, "master", 4, false);
+        assertVersionEquals(p.parse("1.2-master-SNAPSHOT"), 1, 2, null, "master", null, true);
+        assertVersionEquals(p.parse("1.2-gvc-4-5"), 1, 2, null, "gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2-gvc-4-SNAPSHOT"), 1, 2, null, "gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2-release-gvc-4-5"), 1, 2, null, "release-gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2-release-gvc-4-SNAPSHOT"), 1, 2, null, "release-gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2-pks-1234-bnu-integration-5"), 1, 2, null, "pks-1234-bnu-integration", 5, false);
+        assertVersionEquals(p.parse("1.2-pks-1234-bnu-integration-SNAPSHOT"), 1, 2, null, "pks-1234-bnu-integration", null, true);
+        assertVersionEquals(p.parse("1.2.3-master-4"), 1, 2, 3, "master", 4, false);
+        assertVersionEquals(p.parse("1.2.3-master-SNAPSHOT"), 1, 2, 3, "master", null, true);
+        assertVersionEquals(p.parse("1.2.3-gvc-4-5"), 1, 2, 3, "gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2.3-gvc-4-SNAPSHOT"), 1, 2, 3, "gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2.3-release-gvc-4-5"), 1, 2, 3, "release-gvc-4", 5, false);
+        assertVersionEquals(p.parse("1.2.3-release-gvc-4-SNAPSHOT"), 1, 2, 3, "release-gvc-4", null, true);
+        assertVersionEquals(p.parse("1.2.3-pks-1234-bnu-integration-5"), 1, 2, 3, "pks-1234-bnu-integration", 5, false);
+        assertVersionEquals(p.parse("1.2.3-pks-1234-bnu-integration-SNAPSHOT"), 1, 2, 3, "pks-1234-bnu-integration", null, true);
+
     }
 
-    static void assertVersionEquals(VersionParser.Version actual, int major, int middle, int minor, String branch, Integer build, boolean isSnapshot) {
+    static void assertVersionEquals(Version actual, Integer major, Integer middle, Integer minor, String branch, Integer build, boolean isSnapshot) {
         assertThat(actual.getMajorVersion(), equalTo(major));
         assertThat(actual.getMiddleVersion(), equalTo(middle));
         assertThat(actual.getMinorVersion(), equalTo(minor));
         assertThat(actual.getBranchSuffix(), equalTo(branch));
         assertThat(actual.getBuildVersion(), equalTo(build));
         assertThat(actual.getIsItSnapshot(), equalTo(isSnapshot));
+    }
+
+    static void assertParsingThrows(VersionParser parser, String version) {
+        try {
+            parser.parse(version);
+            assertTrue("Parsing succeeded but failure expected", false);
+        } catch (IllegalArgumentException e) {
+
+        }
     }
 
 }

--- a/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionParserTest.java
+++ b/src/test/java/at/nonblocking/maven/nonsnapshot/version/VersionParserTest.java
@@ -15,24 +15,30 @@ public class VersionParserTest {
 
     @Test
     public void noBranch() {
-        assertVersionEquals(parser.parse("1.2.3"), 1, 2, 3, null, null);
-        assertVersionEquals(parser.parse("11.22.33"), 11, 22, 33, null, null);
+        assertVersionEquals(parser.parse("1.2.3"), 1, 2, 3, null, null, false);
+        assertVersionEquals(parser.parse("11.22.33"), 11, 22, 33, null, null, false);
+        assertVersionEquals(parser.parse("11.22.33-SNAPSHOT"), 11, 22, 33, null, null, true);
     }
 
     @Test
     public void withBranch() {
-        assertVersionEquals(parser.parse("1.2.3-master-4"), 1, 2, 3, "master", 4);
-        assertVersionEquals(parser.parse("1.2.3-gvc-4-5"), 1, 2, 3, "gvc-4", 5);
-        assertVersionEquals(parser.parse("1.2.3-release-gvc-4-5"), 1, 2, 3, "release-gvc-4", 5);
-        assertVersionEquals(parser.parse("1.2.3-pks-1234-bnu-integration-5"), 1, 2, 3, "pks-1234-bnu-integration", 5);
+        assertVersionEquals(parser.parse("1.2.3-master-4"), 1, 2, 3, "master", 4, false);
+        assertVersionEquals(parser.parse("1.2.3-master-SNAPSHOT"), 1, 2, 3, "master", null, true);
+        assertVersionEquals(parser.parse("1.2.3-gvc-4-5"), 1, 2, 3, "gvc-4", 5, false);
+        assertVersionEquals(parser.parse("1.2.3-gvc-4-SNAPSHOT"), 1, 2, 3, "gvc-4", null, true);
+        assertVersionEquals(parser.parse("1.2.3-release-gvc-4-5"), 1, 2, 3, "release-gvc-4", 5, false);
+        assertVersionEquals(parser.parse("1.2.3-release-gvc-4-SNAPSHOT"), 1, 2, 3, "release-gvc-4", null, true);
+        assertVersionEquals(parser.parse("1.2.3-pks-1234-bnu-integration-5"), 1, 2, 3, "pks-1234-bnu-integration", 5, false);
+        assertVersionEquals(parser.parse("1.2.3-pks-1234-bnu-integration-SNAPSHOT"), 1, 2, 3, "pks-1234-bnu-integration", null, true);
     }
 
-    static void assertVersionEquals(VersionParser.Version actual, int major, int middle, int minor, String branch, Integer build) {
+    static void assertVersionEquals(VersionParser.Version actual, int major, int middle, int minor, String branch, Integer build, boolean isSnapshot) {
         assertThat(actual.getMajorVersion(), equalTo(major));
         assertThat(actual.getMiddleVersion(), equalTo(middle));
         assertThat(actual.getMinorVersion(), equalTo(minor));
         assertThat(actual.getBranchSuffix(), equalTo(branch));
         assertThat(actual.getBuildVersion(), equalTo(build));
+        assertThat(actual.getIsItSnapshot(), equalTo(isSnapshot));
     }
 
 }


### PR DESCRIPTION
- Allow to provide upstream dependencies in SNAPSHOT version
- Added possibility to version increment by making it SNAPSHOT
- Added support for bom upstream dependencies
- Added updating versions in dependencyManagement section
- Fixed problem with accessing resource folder in tests (hard coded path)
- Fixed problem with incomplete commit message when using deferPomCommit